### PR TITLE
FIX: Tag group appearing when the name of the group is empty

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -50,15 +50,11 @@
     margin: 0 0.5rem;
     caret-color: transparent;
 
-   
-
     &.checked {
       background-color: var(--hover-color);
       color: white;
     }
   }
-
-  
 
   &.checked {
     background-color: var(--primary-medium);
@@ -70,7 +66,7 @@
   display: none;
 }
 
-#custom-filter-logic-selector{
+#custom-filter-logic-selector {
   display: none;
 }
 
@@ -96,5 +92,4 @@
       color: var(--primary);
     }
   }
-  
 }

--- a/common/common.scss
+++ b/common/common.scss
@@ -50,10 +50,7 @@
     margin: 0 0.5rem;
     caret-color: transparent;
 
-    &.filter-tag-label:hover {
-      background-color: var(--hover-color);
-      color: white;
-    }
+   
 
     &.checked {
       background-color: var(--hover-color);
@@ -61,23 +58,7 @@
     }
   }
 
-  &.custom-filter-logic-selector {
-    display: flex;
-    direction: row;
-    padding: 0.625em 1em !important;
-    background-color: var(--primary-low);
-    box-shadow: var(--box-shadow);
-    border: 0px;
-    color: var(--primary);
-    cursor: pointer;
-    transition: background-color 0.3s, color 0.3s;
-    position: relative;
-    margin: 0 0.5rem;
-  }
-
-  &.custom-filter-logic-selector:hover {
-    background-color: var(--primary-medium);
-  }
+  
 
   &.checked {
     background-color: var(--primary-medium);
@@ -87,4 +68,33 @@
 
 .filter-tag-input {
   display: none;
+}
+
+#custom-filter-logic-selector{
+  display: none;
+}
+
+.custom-filter-logic-selector {
+  display: flex;
+  direction: row;
+  padding: 0.625em 1em !important;
+  background-color: var(--primary-low);
+  box-shadow: var(--box-shadow);
+  border: 0px;
+  color: var(--primary);
+  cursor: pointer;
+  transition: background-color 0.3s, color 0.3s;
+  position: relative;
+  margin: 0 0.5rem;
+
+  &.checked {
+    background-color: var(--primary-medium);
+    color: white;
+
+    &:hover {
+      background-color: var(--primary-low);
+      color: var(--primary);
+    }
+  }
+  
 }

--- a/javascripts/discourse/templates/components/custom-filter.hbs
+++ b/javascripts/discourse/templates/components/custom-filter.hbs
@@ -20,23 +20,22 @@
       </label>
       <ul class="custom-filters__tags">
         {{#each this.tagGroups as |tagGroup|}}
-          <li class="custom-filters__group">
-            <h2>{{tagGroup.name}}</h2>
-            <div class="custom-filters__list">
-
-              {{#each tagGroup.tags as |tag|}}
-                <FilterTag
-                  @name={{tag}}
-                  @selectTag={{this.selectTag}}
-                  @deselectTag={{this.deselectTag}}
-                  @selectedTags={{this.selectedTags}}
-                />
-              {{/each}}
-
-            </div>
-          </li>
+          {{#if tagGroup.name}}
+            <li class="custom-filters__group">
+              <h2>{{tagGroup.name}}</h2>
+              <div class="custom-filters__list">
+                {{#each tagGroup.tags as |tag|}}
+                  <FilterTag
+                    @name={{tag}}
+                    @selectTag={{this.selectTag}}
+                    @deselectTag={{this.deselectTag}}
+                    @selectedTags={{this.selectedTags}}
+                  />
+                {{/each}}
+              </div>
+            </li>
+          {{/if}}
         {{/each}}
-
       </ul>
       <DButton
         class="custom-filters__button"


### PR DESCRIPTION
Fix for when a Tag group doesn't have a name. Instead of showing up as an empty label it won't show anymore. Also, there is a fix for the `or` logic filter button so that it shows as checked correctly 