### PR TITLE
DEV: Use slug+id tag URLs to support new canonical tag routes

### DIFF
--- a/javascripts/discourse/components/custom-filter.gjs
+++ b/javascripts/discourse/components/custom-filter.gjs
@@ -6,6 +6,7 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";
 import concatClass from "discourse/helpers/concat-class";
+import { ajax } from "discourse/lib/ajax";
 import DiscourseURL from "discourse/lib/url";
 import { i18n } from "discourse-i18n";
 import FilterTag from "./filter-tag";
@@ -96,11 +97,10 @@ export default class CustomFilter extends Component {
   }
 
   @action
-  applyFilters() {
-    const tagsPath = this.selectedTags.join("/");
-
+  async applyFilters() {
     let transitionURL = "";
     if (this.selectedTags.length > 1) {
+      const tagsPath = this.selectedTags.join("/");
       transitionURL = `/tags/intersection/${tagsPath}`;
     } else if (this.selectedTags.length === 0) {
       transitionURL = this.category.slug
@@ -108,9 +108,12 @@ export default class CustomFilter extends Component {
         : "/latest";
       DiscourseURL.routeTo(transitionURL);
     } else {
+      const tagName = this.selectedTags[0];
+      const result = await ajax(`/tag/${tagName}/info.json`);
+      const tag = result.tag_info;
       transitionURL = this.category.slug
-        ? `/tags/c/${this.category.slug}/${tagsPath}`
-        : `/tag/${tagsPath}`;
+        ? `/tags/c/${this.category.slug}/${this.category.id}/${tag.slug}/${tag.id}`
+        : `/tag/${tag.slug}/${tag.id}`;
     }
 
     let params = [];

--- a/test/acceptance/custom-filter-test.js
+++ b/test/acceptance/custom-filter-test.js
@@ -9,10 +9,22 @@ acceptance("Custom Filter | tag route", function (needs) {
   needs.settings({ tagging_enabled: true });
 
   needs.pretender((server, helper) => {
-    server.get("/tag/important/l/latest.json", () => {
+    server.get("/tag/1/l/latest.json", () => {
       return helper.response(
         cloneJSON(discoveryFixture["/tag/important/l/latest.json"])
       );
+    });
+    server.get("/tag/important/info.json", () => {
+      return helper.response({
+        tag_info: {
+          id: 1,
+          name: "important",
+          slug: "important",
+          description: "Important topics for discussion",
+          topic_count: 5,
+          pm_only: false,
+        },
+      });
     });
   });
 


### PR DESCRIPTION
Discourse core is moving canonical tag routes from `/tag/name` to `/tag/slug/id` (discourse/discourse#37055). This updates the `applyFilters` action to use the new URL format when navigating to single-tag routes.

Instead of building tag URLs from just the tag name, we now fetch tag info via `/tag/:name/info.json` to get the tag's slug and id, then construct the correct slug+id-based URLs for both standalone tag routes (`/tag/:slug/:id`) and category+tag routes (`/tags/c/:category_slug/:category_id/:tag_slug/:tag_id`).

Demo

https://github.com/user-attachments/assets/b6082507-3215-4286-a0b1-4252e9f5cc4d

